### PR TITLE
Update ImagePickerUtils.m

### DIFF
--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -70,6 +70,17 @@
     
     configuration.selectionLimit = [options[@"selectionLimit"] integerValue];
 
+    if (@available(iOS 15, *)) {
+        configuration.selection = PHPickerConfigurationSelectionOrdered;
+    } 
+    
+    if (options[@"preselectedAssetIdentifiers"] != nil) {
+        NSArray<NSString *> *preselectedAssetIdentifiers = [RCTConvert NSStringArray:options[@"preselectedAssetIdentifiers"]];
+        if (@available(iOS 15, *)) {
+            configuration.preselectedAssetIdentifiers = preselectedAssetIdentifiers;
+        } 
+    } 
+
     if ([options[@"mediaType"] isEqualToString:@"video"]) {
         configuration.filter = [PHPickerFilter videosFilter];
     } else if ([options[@"mediaType"] isEqualToString:@"photo"]) {


### PR DESCRIPTION
Support shows re-ordering the selection behavior for the picker.  And preselectedAssetIdentifiers option to show pre-selected assets (IOS 15+)

Thanks for submitting a PR! Please read these instructions carefully:

TODO:
- Create library interface and document about _preselectedAssetIdentifiers_ props
- Make assets selection ordered as optional options